### PR TITLE
Fixed warning generated by intx.dart superclass

### DIFF
--- a/lib/src/fixnum/intx.dart
+++ b/lib/src/fixnum/intx.dart
@@ -48,7 +48,7 @@ abstract class intx implements Comparable {
   bool isOdd();
   bool isZero();
 
-  int hashCode;
+  int get hashCode;
 
   intx abs();
 


### PR DESCRIPTION
Fixed warning generated by intx.dart superclass
