### PR TITLE
Added a dateTime getter + test on ObjectId equivalent to mongo shells' g...

### DIFF
--- a/lib/src/types/objectid.dart
+++ b/lib/src/types/objectid.dart
@@ -10,6 +10,7 @@ class ObjectId extends BsonObject{
   ObjectId.fromSeconds(int seconds, [bool clientMode = false]){
     id = createId(seconds, clientMode);
   }
+  
   ObjectId.fromBsonBinary(this.id);
 
   BsonBinary createId(int seconds, bool clientMode) {
@@ -31,11 +32,9 @@ class ObjectId extends BsonObject{
     }
   }
 
-
   factory ObjectId.fromHexString(String hexString) {
     return new ObjectId.fromBsonBinary(new BsonBinary.fromHexString(hexString));
   }
-
 
   int get hashCode => id.hexString.hashCode;
   bool operator ==(other) => other is ObjectId && toHexString() == other.toHexString();
@@ -44,10 +43,12 @@ class ObjectId extends BsonObject{
   int get typeByte => _BSON_DATA_OID;
   get value => this;
   int byteLength() => 12;
+  
   unpackValue(BsonBinary buffer){
      id.byteList.setRange(0,12,buffer.byteList,buffer.offset);
      buffer.offset += 12;
   }
+  
   packValue(BsonBinary buffer){
     if (id.byteList == null) {
       id.makeByteList();
@@ -60,4 +61,7 @@ class ObjectId extends BsonObject{
     return '\{"\$oid":"${toHexString()}"\}';
   }
 
+  // Equivalent to mongo shell's "getTimestamp".
+  DateTime get dateTime => new DateTime.fromMillisecondsSinceEpoch(int.parse(id.hexString.substring(0, 8), radix:16) * 1000);
+ 
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: bson
-version: 0.1.5
+version: 0.1.6
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
-- '  Ad van der Veer <advanderveer@gmail.com>'
+- '   Ad van der Veer <advanderveer@gmail.com>'
 description: Bson library for Dart programming language. BSON, short for Binary JSON, is a binary-encoded serialization of JSON-like documents.
 homepage: https://github.com/vadimtsushko/bson
 dev_dependencies:

--- a/test/bson_test_lib.dart
+++ b/test/bson_test_lib.dart
@@ -81,6 +81,16 @@ testObjectId(){
   expect("0000000a",leading8chars, reason: 'Timestamp part of ObjectId must be encoded BigEndian');
 }
 
+testObjectIdDateTime(){
+  // Equivalent to getTimestamp in mongoShell... this library has it's own "timestamp" concept that differs.
+  // Expect equivalent too: 1372093057000 / Mon Jun 24 2013 11:57:37 GMT-0500 (Central Daylight Time) from 51c87a81a58a563d1304f4ed 
+  var objectId = new ObjectId.fromHexString("51c87a81a58a563d1304f4ed");  
+  var expected = new DateTime.fromMillisecondsSinceEpoch(1372093057000);
+  var actual = objectId.dateTime;
+  
+  expect(expected, actual);
+}
+
 testSerializeDeserialize(){
   var bson = new BSON();
   var map = {'_id':5, 'a':4};
@@ -176,6 +186,7 @@ run(){
   });
   group("ObjectId:", (){
     test("testObjectId",testObjectId);
+    test("testObjectIdDateTime",testObjectIdDateTime);    
     test("testBsonIdFromHexString",testBsonIdFromHexString);
     test("testBsonIdClientMode",testBsonIdClientMode);
     test("testBsonDbPointer", testBsonDbPointer);


### PR DESCRIPTION
...etTimestamp

Did not use "getTimestamp" as name as lib already has a class Timestamp and the
return type is just a dart DateTime.
