### PR TITLE
Fix for larger dart's integer to mongo long

### DIFF
--- a/lib/src/bson_type.dart
+++ b/lib/src/bson_type.dart
@@ -97,12 +97,11 @@ BsonObject bsonObjectFrom(var value){
     return value;
   }
   if (value is int){
-    return new BsonInt(value);
+    return value.bitLength > 31 ? new BsonLong(value) : new BsonInt(value)
   }
   if (value is num){
     return new BsonDouble(value);
   }
-
   if (value is String){
     return new BsonString(value);
   }


### PR DESCRIPTION
Since dart allows larger integer than Bson there is need to convert larger integers to BsonLong to prevent overflow
