### PR TITLE
Add missing typeByte getter on Timestamp class

### DIFF
--- a/lib/src/types/timestamp.dart
+++ b/lib/src/types/timestamp.dart
@@ -11,6 +11,7 @@ class Timestamp extends BsonObject{
     }
   }
   get value=>this;
+  int get typeByte => _BSON_DATA_TIMESTAMP;
   String toString()=>"Timestamp($seconds, $increment)";
   int byteLength() => 8;
   packValue(BsonBinary buffer){


### PR DESCRIPTION
typebyte getter is required when packing Timestamp instance in a query message
