### PR TITLE
Add BSON_DATA_UNDEFINED type (as clone of BSON_DATA_NULL)

### DIFF
--- a/lib/src/bson_type.dart
+++ b/lib/src/bson_type.dart
@@ -14,6 +14,9 @@ const _BSON_DATA_ARRAY = 4;
 /** BsonBinary BSON Type **/
 const _BSON_DATA_BINARY = 5;
 
+/** undefined BSON Type **/
+const _BSON_DATA_UNDEFINED = 6;
+
 /** ObjectID BSON Type **/
 const _BSON_DATA_OID = 7;
 
@@ -42,7 +45,7 @@ const _BSON_DATA_LONG = 18;
 const _BSON_DATA_CODE = 13;
 
 /** Timestamp BSON Type **/
-const _BSON_DATA_TIMESTAMP = 17; 
+const _BSON_DATA_TIMESTAMP = 17;
 
 /** The following types are implemented partially **/
 //static const BSON_DATA_MIN_KEY = 0xff; MinKey BSON Type
@@ -140,6 +143,8 @@ BsonObject bsonObjectFromTypeByte(int typeByte){
       return new BsonArray([]);
     case _BSON_DATA_OBJECT:
       return new BsonMap({});
+    case _BSON_DATA_UNDEFINED:
+      return new BsonNull();
     case _BSON_DATA_OID:
       return new ObjectId();
     case _BSON_DATA_NULL:


### PR DESCRIPTION
On MongoDB shell, "undefined" value can be inserted on document.
If you do so, mongo_dart driver won't be able to retrieve the document.

First of all, Dart and JSON don't support "undefined" value and they only use "null".
It seems that MongoDB considers "undefined" value as "null" value.

See following commands on MongoDB shell as confirmation.

```
> a = { "x": "3"}
{ "x" : "3" }
> a.y = a.z
> a
{ "x" : "3", "y" : undefined }
> db.foo.insert(a)
WriteResult({ "nInserted" : 1 })
> db.foo.find()
{ "_id" : ObjectId("5409ca2659de2af23b089900"), "x" : "3", "y" : null }
> db.foo.find({"y": null})
{ "_id" : ObjectId("5409ca2659de2af23b089900"), "x" : "3", "y" : null }
> db.foo.find({"y": {"$type":6}})
{ "_id" : ObjectId("5409ca2659de2af23b089900"), "x" : "3", "y" : null }
> db.foo.find({"y": {"$type":10}})
>
```
