### PR TITLE
Remove redundant type check in bsonObjectFrom

### DIFF
--- a/lib/src/bson_type.dart
+++ b/lib/src/bson_type.dart
@@ -123,9 +123,6 @@ BsonObject bsonObjectFrom(var value){
   if (value == true || value == false){
     return new BsonBoolean(value);
   }
-  if (value is BsonRegexp){
-    return value;
-  }
   throw new Exception("Not implemented for $value");
 }
 


### PR DESCRIPTION
Checking BsonRegexp is redundant because it is a subclass of BsonObject
which is already checked.