### PR TITLE
Set a limit for the number keys that are cached

### DIFF
--- a/lib/bson.dart
+++ b/lib/bson.dart
@@ -2,6 +2,7 @@ library bson;
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
+import 'dart:collection';
 import 'package:more/char_matcher.dart';
 import 'package:fixnum/fixnum.dart';
 part 'src/bson_type.dart';

--- a/lib/src/statics.dart
+++ b/lib/src/statics.dart
@@ -1,43 +1,55 @@
 part of bson;
-class _Statics{
+
+class _Statics {
   static Stopwatch _stopwatch;
   static startStopwatch() => _stopwatch = new Stopwatch()..start();
   static stopStopwatch() => _stopwatch.stop();
-  static Duration getElapsedTime(){
+  static Duration getElapsedTime() {
     _stopwatch.stop();
     return new Duration(milliseconds: _stopwatch.elapsedMilliseconds);
   }
+
   static int _current_increment = new Random().nextInt(0xFFFFFFFF);
-  static int get nextIncrement
-  {
+  static int get nextIncrement {
     return _current_increment++;
   }
+
   static int _requestId;
-  static int get nextRequestId
-  {
-    if (_requestId == null)
-    {
+  static int get nextRequestId {
+    if (_requestId == null) {
       _requestId = 1;
     }
     return ++_requestId;
   }
 
   static List<int> _maxBits;
-  static int MaxBits(int bits){
-    if (_maxBits == null){
+  static int MaxBits(int bits) {
+    if (_maxBits == null) {
       _maxBits = new List<int>(65);
       _maxBits[0] = 0;
       for (var i = 1; i < 65; i++) {
-        _maxBits[i]=(2 << i-1);
+        _maxBits[i] = (2 << i - 1);
       }
     }
     return _maxBits[bits];
   }
+
   static final int RandomId = new Random().nextInt(0xFFFFFFFF);
-  static final Map<String,List<int>> keys = new Map<String,List<int>>();
-  static getKeyUtf8(String key){
-    if (!keys.containsKey(key)){
-      keys[key] = UTF8.encode(key);
+  static final int _MAX_KEYS = 1000;
+  static final LinkedHashMap<String, List<int>> keys =
+      new LinkedHashMap<String, List<int>>();
+  static getKeyUtf8(String key) {
+    if (!keys.containsKey(key)) {
+      List<int> encoded = UTF8.encode(key);
+      if (keys.length >= _MAX_KEYS) {
+        String k = keys.keys.first;
+        keys.remove(k);
+      }
+      keys.putIfAbsent(key, () => encoded);
+    } else {
+      var v = keys.remove(key);
+      // add to the back
+      keys.putIfAbsent(key, () => v);
     }
     return keys[key];
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bson
-version: 0.3.1
+version: 0.3.2
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
 - Ad van der Veer <advanderveer@gmail.com>


### PR DESCRIPTION
Unbounded keys could cause out of memory. We need to have a bounded cache. The implementation store the most recently used keys and remove the least recently used. 

