### PR TITLE
updated Endian, utf8, json; updated dart sdk, dependencies

### DIFF
--- a/lib/src/statics.dart
+++ b/lib/src/statics.dart
@@ -37,7 +37,7 @@ class _Statics{
   static final Map<String,List<int>> keys = new Map<String,List<int>>();
   static getKeyUtf8(String key){
     if (!keys.containsKey(key)){
-      keys[key] = UTF8.encode(key);
+      keys[key] = utf8.encode(key);
     }
     return keys[key];
   }

--- a/lib/src/types/binary.dart
+++ b/lib/src/types/binary.dart
@@ -106,7 +106,7 @@ class BsonBinary extends BsonObject{
       pos++;
     }
   }
-  setIntExtended(int value, int numOfBytes, Endianness endianness){
+  setIntExtended(int value, int numOfBytes, Endian endianness){
     List<int> byteListTmp = new Uint8List(4);
     var byteArrayTmp = _getByteData(byteListTmp);
     if (numOfBytes == 3){
@@ -130,7 +130,7 @@ class BsonBinary extends BsonObject{
       swap(i,numOfBytes-1-i);
     }
   }
-  encodeInt(int position,int value, int numOfBytes, Endianness endianness, bool signed) {
+  encodeInt(int position,int value, int numOfBytes, Endian endianness, bool signed) {
     switch(numOfBytes) {
       case 4:
         byteArray.setInt32(position,value,endianness);
@@ -145,16 +145,16 @@ class BsonBinary extends BsonObject{
         throw new Exception("Unsupported num of bytes: $numOfBytes");
     }
   }
-  void writeInt(int value, {int numOfBytes:4, endianness: Endianness.LITTLE_ENDIAN, bool signed:false}){
+  void writeInt(int value, {int numOfBytes:4, endianness: Endian.little, bool signed:false}){
     encodeInt(offset,value, numOfBytes,endianness,signed);
     offset += numOfBytes;
   }
   writeByte(int value){
-    encodeInt(offset,value, 1,Endianness.LITTLE_ENDIAN,false);
+    encodeInt(offset,value, 1,Endian.little,false);
     offset += 1;
   }
   void writeDouble(double value){
-    byteArray.setFloat64(offset, value,Endianness.LITTLE_ENDIAN);
+    byteArray.setFloat64(offset, value,Endian.little);
     offset+=8;
   }
   void writeInt64(int value){
@@ -163,7 +163,7 @@ class BsonBinary extends BsonObject{
       byteList.setRange(offset,offset+8,d64.toBytes());
     }
     else {
-      byteArray.setInt64(offset, value,Endianness.LITTLE_ENDIAN);
+      byteArray.setInt64(offset, value,Endian.little);
     }
     offset+=8;
   }
@@ -172,7 +172,7 @@ class BsonBinary extends BsonObject{
   }
   int readInt32(){
     offset+=4;
-    return byteArray.getInt32(offset-4,Endianness.LITTLE_ENDIAN);
+    return byteArray.getInt32(offset-4,Endian.little);
   }
   int readInt64(){
     offset+=8;
@@ -183,11 +183,11 @@ class BsonBinary extends BsonObject{
       var i64 = new Int64.fromInts(i2, i1);
       return i64.toInt();
     }
-    return byteArray.getInt64(offset-8,Endianness.LITTLE_ENDIAN);
+    return byteArray.getInt64(offset-8,Endian.little);
   }
   num readDouble(){
     offset+=8;
-    return byteArray.getFloat64(offset-8,Endianness.LITTLE_ENDIAN);
+    return byteArray.getFloat64(offset-8,Endian.little);
   }
 
   String readCString(){
@@ -195,10 +195,10 @@ class BsonBinary extends BsonObject{
     while (byteList[offset++]!= 0){
        stringBytes.add(byteList[offset-1]);
     }
-    return UTF8.decode(stringBytes);
+    return utf8.decode(stringBytes);
   }
   writeCString(String val){
-    final utfData = UTF8.encode(val);
+    final utfData = utf8.encode(val);
     byteList.setRange(offset,offset+utfData.length,utfData);
     offset += utfData.length;
     writeByte(0);

--- a/lib/src/types/objectid.dart
+++ b/lib/src/types/objectid.dart
@@ -27,9 +27,9 @@ class ObjectId extends BsonObject{
       return new BsonBinary.fromHexString(s);
     } else {
       return new BsonBinary(12)
-      ..writeInt(seconds,endianness: Endianness.BIG_ENDIAN)
+      ..writeInt(seconds,endianness: Endian.big)
       ..writeInt(_Statics.RandomId)
-      ..writeInt(_Statics.nextIncrement,endianness: Endianness.BIG_ENDIAN);
+      ..writeInt(_Statics.nextIncrement,endianness: Endian.big);
     }
   }
 

--- a/lib/src/types/string.dart
+++ b/lib/src/types/string.dart
@@ -4,7 +4,7 @@ class BsonString extends BsonObject{
   List<int> _utfData;
   List<int> get utfData{
     if (_utfData == null){
-      _utfData = UTF8.encode(data);
+      _utfData = utf8.encode(data);
     }
     return _utfData;
   }
@@ -20,7 +20,7 @@ class BsonString extends BsonObject{
   }
   unpackValue(BsonBinary buffer){
      int size = buffer.readInt32()-1;
-     data = UTF8.decode(buffer.byteList.getRange(buffer.offset, buffer.offset+size).toList());
+     data = utf8.decode(buffer.byteList.getRange(buffer.offset, buffer.offset+size).toList());
      buffer.offset += size+1;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: bson
-version: 0.3.1
+version: 0.3.2
 authors:
 - Vadim Tsushko <vadimtsushko@gmail.com>
 - Ad van der Veer <advanderveer@gmail.com>
 description: Bson library for Dart programming language. BSON, short for Binary JSON, is a binary-encoded serialization of JSON-like documents.
 homepage: https://github.com/vadimtsushko/bson
 environment:
-  sdk: '>=0.8.10+6 <2.0.0'
+  sdk: '>=2.0.0-dev.69.2 <3.0.0'
 dependencies:
-  fixnum: '>=0.9.0 <2.0.0'
-  more: '>=1.3.2 <2.0.0'
+  fixnum: '^0.10.8'
+  more: '^1.9.2'
 dev_dependencies:
-  browser: '>=0.9.0'
-  test: ">=0.12.2"
-  dart_coveralls: ">=0.1.11"
+  #browser: '^0.10.0+3'
+  test: '^1.3.0'
+  #dart_coveralls: '^0.6.0+1'

--- a/test/bson_test_lib.dart
+++ b/test/bson_test_lib.dart
@@ -27,11 +27,11 @@ testBsonBinary() {
   expect('0000000004030201', b.hexString);
   b = new BsonBinary(8);
   b.writeInt(0);
-  b.writeInt(0x01020304, numOfBytes: 4, endianness: Endianness.BIG_ENDIAN);
+  b.writeInt(0x01020304, numOfBytes: 4, endianness: Endian.big);
   expect(b.hexString, '0000000001020304');
   b = new BsonBinary(8);
   b.writeInt(0);
-  b.writeInt(1, endianness: Endianness.BIG_ENDIAN);
+  b.writeInt(1, endianness: Endian.big);
   expect(b.hexString, '0000000000000001');
   b = new BsonBinary(4);
   b.writeInt(-1);
@@ -126,7 +126,7 @@ testMakeByteList() {
   }
   var b = new BsonBinary.fromHexString('0301');
   b.makeByteList();
-  expect(b.byteArray.getInt16(0, Endianness.LITTLE_ENDIAN), 259);
+  expect(b.byteArray.getInt16(0, Endian.little), 259);
   b = new BsonBinary.fromHexString('0301ad0c1ad34f1d');
   b.makeByteList();
   expect(b.hexString, '0301ad0c1ad34f1d');
@@ -185,11 +185,11 @@ run() {
       expect('0000000004030201', b.hexString);
       b = new BsonBinary(8);
       b.writeInt(0);
-      b.writeInt(0x01020304, numOfBytes: 4, endianness: Endianness.BIG_ENDIAN);
+      b.writeInt(0x01020304, numOfBytes: 4, endianness: Endian.big);
       expect(b.hexString, '0000000001020304');
       b = new BsonBinary(8);
       b.writeInt(0);
-      b.writeInt(1, endianness: Endianness.BIG_ENDIAN);
+      b.writeInt(1, endianness: Endian.big);
       expect(b.hexString, '0000000000000001');
       b = new BsonBinary(4);
       b.writeInt(-1);
@@ -215,7 +215,7 @@ run() {
       }
       var b = new BsonBinary.fromHexString('0301');
       b.makeByteList();
-      expect(b.byteArray.getInt16(0, Endianness.LITTLE_ENDIAN), 259);
+      expect(b.byteArray.getInt16(0, Endian.little), 259);
       b = new BsonBinary.fromHexString('0301ad0c1ad34f1d');
       b.makeByteList();
       expect(b.hexString, '0301ad0c1ad34f1d');
@@ -303,8 +303,8 @@ run() {
       var id = new ObjectId();
       var date = new DateTime.utc(2015, 1, 1);
       var obj = {'_id': id, 'intFld': 20, 'dateFld': date};
-      String jsObj = JSON.encode(obj, toEncodable: _toEncodable);
-      var outObj = JSON.decode(jsObj);
+      String jsObj = json.encode(obj, toEncodable: _toEncodable);
+      var outObj = json.decode(jsObj);
       expect(outObj['intFld'], 20);
       expect(outObj['_id'], id.toHexString());
       expect(outObj['dateFld'], date.toString());


### PR DESCRIPTION
Per issue #27, updated Endianness references to Endian, with corresponding updated constants.  Also updated references for UTF8 to utf8, and JSON to json.

Updated Dart SDK constraint.  Updated dependency versions (except for dart_coveralls; package still needs to be updated for Dart 2).  Removed dependency on 'browser' packages, as it is no longer needed with Dart 2.

Incremented version from 0.3.1 to 0.3.2.