### PR TITLE
Fixed missing casts to decimal

### DIFF
--- a/lib/src/extension/decimal_extension.dart
+++ b/lib/src/extension/decimal_extension.dart
@@ -121,7 +121,7 @@ extension DecimalExt on Decimal {
       /// the length. Maybe that there is a cleaner way,
       var pwr =
           requiredPrecision + toRational().denominator.toRadixString(10).length;
-      var shifter = Decimal.ten.pow(pwr);
+      var shifter = Decimal.ten.pow(pwr).toDecimal();
       Decimal decimal = ((this * shifter).round() / shifter).toDecimal();
       return decimal.toStringAsPrecisionFast(requiredPrecision);
     }
@@ -161,7 +161,7 @@ extension DecimalExt on Decimal {
     } else {
       /// given the exponent, we calculate the value to be used in order
       /// to shift our number
-      var coefficient = Decimal.ten.pow(shiftExponent);
+      var coefficient = Decimal.ten.pow(shiftExponent).toDecimal();
 
       /// here we shift the number and round, so that we loose the non required
       /// precision digits (if any), and then we move back the digits in the

--- a/lib/src/types/decimal_128.dart
+++ b/lib/src/types/decimal_128.dart
@@ -33,10 +33,11 @@ final significand2Mask = Int64.parseHex('00007FFFFFFFFFFF');
 final significand2impliedMask = Int64.parseHex('2000000000000');
 
 final Decimal infinityValue =
-    Decimal.parse('10000000000000000000000000000000000').pow(10000);
-final Decimal maxSignificand = Decimal.fromInt(10).pow(34) - Decimal.one;
-final Decimal maxUInt64 = Decimal.fromInt(2).pow(64);
-final Decimal maxInt64 = Decimal.fromInt(2).pow(63);
+    Decimal.parse('10000000000000000000000000000000000').pow(10000).toDecimal();
+final Decimal maxSignificand =
+    Decimal.fromInt(10).pow(34).toDecimal() - Decimal.one;
+final Decimal maxUInt64 = Decimal.fromInt(2).pow(64).toDecimal();
+final Decimal maxInt64 = Decimal.fromInt(2).pow(63).toDecimal();
 final Decimal _d10 = Decimal.fromInt(10);
 final Decimal _d1 = Decimal.fromInt(1);
 
@@ -195,7 +196,7 @@ class BsonDecimal128 extends BsonObject {
       significand = -significand;
     }
 
-    return significand * _d10.pow(exponent.toInt());
+    return significand * _d10.pow(exponent.toInt()).toDecimal();
   }
 
   static BsonBinary convertDecimalToBinary(Decimal? decimal) {

--- a/test/bson_decimal_128_test_lib.dart
+++ b/test/bson_decimal_128_test_lib.dart
@@ -20,18 +20,18 @@ void runDecimal128() {
       test('Detect Exponent decimal', () {
         var dec = Decimal.parse('0.45');
         expect(BsonDecimal128.extractExponent(dec.toStringAsPrecision(34)), -2);
-        expect(dec, Decimal.parse('4.5') * ten.pow(-1));
+        expect(dec, Decimal.parse('4.5') * ten.pow(-1).toDecimal());
         dec = Decimal.parse('0.00045');
         expect(BsonDecimal128.extractExponent(dec.toStringAsPrecision(34)), -5);
-        expect(dec, Decimal.parse('45') * ten.pow(-5));
+        expect(dec, Decimal.parse('45') * ten.pow(-5).toDecimal());
       });
       test('Detect Exponent high numbers', () {
         var dec = Decimal.parse('1000');
         expect(BsonDecimal128.extractExponent(dec.toStringAsPrecision(34)), 3);
-        expect(dec, Decimal.one * ten.pow(3));
+        expect(dec, Decimal.one * ten.pow(3).toDecimal());
         dec = Decimal.parse('27564578390000000');
         expect(BsonDecimal128.extractExponent(dec.toStringAsPrecision(34)), 7);
-        expect(dec, Decimal.parse('2756457839') * ten.pow(7));
+        expect(dec, Decimal.parse('2756457839') * ten.pow(7).toDecimal());
       });
 
       test('Detect Significand', () {
@@ -48,24 +48,26 @@ void runDecimal128() {
         var dec = Decimal.parse('0.45');
         expect(BsonDecimal128.extractSignificand(dec.toStringAsPrecision(34)),
             Decimal.fromInt(45));
-        expect(dec, Decimal.fromInt(45) * ten.pow(-1 + 1 - ('45'.length)));
+        expect(dec,
+            Decimal.fromInt(45) * ten.pow(-1 + 1 - ('45'.length)).toDecimal());
         dec = Decimal.parse('0.00045');
         expect(BsonDecimal128.extractSignificand(dec.toStringAsPrecision(34)),
             Decimal.fromInt(45));
-        expect(dec, Decimal.fromInt(45) * ten.pow(-4 + 1 - ('45'.length)));
+        expect(dec,
+            Decimal.fromInt(45) * ten.pow(-4 + 1 - ('45'.length)).toDecimal());
       });
       test('Detect Significand high numbers', () {
         var dec = Decimal.parse('1000');
         expect(BsonDecimal128.extractSignificand(dec.toStringAsPrecision(34)),
             Decimal.one);
-        expect(dec, Decimal.one * ten.pow(3 + 1 - ('1'.length)));
+        expect(dec, Decimal.one * ten.pow(3 + 1 - ('1'.length)).toDecimal());
         dec = Decimal.parse('27564578390000000');
         expect(BsonDecimal128.extractSignificand(dec.toStringAsPrecision(34)),
             Decimal.parse('2756457839'));
         expect(
             dec,
             Decimal.parse('2756457839') *
-                ten.pow(16 + 1 - ('2756457839'.length)));
+                ten.pow(16 + 1 - ('2756457839'.length)).toDecimal());
       });
       test('Compare', () {
         expect(


### PR DESCRIPTION
Hi,

Version 2.3.0 of the ```decimal``` package introduced a breaking change, which this PR adapts to.

Thanks!

Rui