### PR TITLE
Use fromString constructor when creating UuidValues

### DIFF
--- a/lib/src/types/bson_uuid.dart
+++ b/lib/src/types/bson_uuid.dart
@@ -15,7 +15,7 @@ class BsonUuid extends BsonBinary {
   BsonUuid.fromHexString(String hexString)
       : super.fromHexString(hexString, subType: BsonBinary.subtypeUuid);
 
-  factory BsonUuid.parse(String uuidString) => BsonUuid(UuidValue(uuidString));
+  factory BsonUuid.parse(String uuidString) => BsonUuid(UuidValue.fromString(uuidString));
 
   factory BsonUuid.fromBuffer(BsonBinary buffer) {
     var ret = BsonBinary.fromBuffer(buffer);
@@ -27,7 +27,7 @@ class BsonUuid extends BsonBinary {
   }
 
   factory BsonUuid.fromEJson(Map<String, dynamic> eJsonMap) =>
-      BsonUuid(UuidValue(extractEJson(eJsonMap)));
+      BsonUuid(UuidValue.fromString(extractEJson(eJsonMap)));
 
   static String extractEJson(Map<String, dynamic> eJsonMap) {
     var entry = eJsonMap.entries.first;

--- a/test/ejson_test.dart
+++ b/test/ejson_test.dart
@@ -368,7 +368,7 @@ void main() {
       });
     });
     group('Uuid', () {
-      var uuid = UuidValue('c8edabc3-f738-4ca3-b68d-ab92a91478a3');
+      var uuid = UuidValue.fromString('c8edabc3-f738-4ca3-b68d-ab92a91478a3');
       var sourceMap = {'uuid': uuid};
       var hexBuffer =
           '200000000575756964001000000004c8edabc3f7384ca3b68dab92a91478a300';
@@ -1134,7 +1134,7 @@ void main() {
         expect(result['_id'], 5);
       }, skip: 'To Be developed yet');
       test('Uuid', () {
-        var uuid = UuidValue('6BA7B811-9DAD-11D1-80B4-00C04FD430C8');
+        var uuid = UuidValue.fromString('6BA7B811-9DAD-11D1-80B4-00C04FD430C8');
         var map = {'_id': 5, 'uuid': uuid};
         var buffer = EJsonCodec.serialize(map);
         expect(

--- a/test/test_objects/uuid.dart
+++ b/test/test_objects/uuid.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
 groupUuid() {
-  var uuid = UuidValue('c8edabc3-f738-4ca3-b68d-ab92a91478a3');
+  var uuid = UuidValue.fromString('c8edabc3-f738-4ca3-b68d-ab92a91478a3');
   var sourceMap = {'uuid': uuid};
   var hexBuffer =
       '200000000575756964001000000004c8edabc3f7384ca3b68dab92a91478a300';


### PR DESCRIPTION
Context: https://github.com/daegalus/dart-uuid/issues/98

The 4.x update of the `uuid` dependency changed the behavior of the `UuidValue` default/empty constructor , which this package uses. On 3.x version the value was automatically turned into lowercase, but not in the new version. This constructor is also documented to not use it directly https://github.com/daegalus/dart-uuid/blob/7069df5885b1165ac85828d8841c81a00508da09/lib/uuid_value.dart#L44

This PR updates the calls to the default constructor with calls to the new equivalent constructor, so that behavior after the upgrade remains the same.