### PR TITLE
Fix Timestamp Cast

### DIFF
--- a/lib/src/types/bson_timestamp.dart
+++ b/lib/src/types/bson_timestamp.dart
@@ -30,7 +30,7 @@ class BsonTimestamp extends BsonObject {
       throw ArgumentError(
           'The received Map is not a valid EJson Timestamp representation');
     }
-    var content = entry.value as Map<String, Object>;
+    var content = (entry.value as Map).cast<String, Object>();
     if (content.containsKey('t') && content.containsKey('i')) {
       int seconds = content['t'] as int;
       int increment = content['i'] as int;

--- a/test/test_objects/timestamp.dart
+++ b/test/test_objects/timestamp.dart
@@ -98,4 +98,9 @@ groupTimestamp() {
       type$timestamp: {'t': 129984774, 'i': 2}
     });
   });
+  test('Ejson Deserializes After Serialization', () {
+    final ejsonString = EJsonCodec.stringify(EJsonCodec.doc2eJson(sourceMap));
+    final timestampDoc = EJsonCodec.eJson2Doc(EJsonCodec.parse(ejsonString));
+    expect(timestampDoc, sourceMap);
+  });
 }


### PR DESCRIPTION
Timestamp deserialization threw a type error when a document with a timestamp was parsed.