### PR TITLE
More json deserialization fixes

### DIFF
--- a/lib/bson.dart
+++ b/lib/bson.dart
@@ -9,6 +9,7 @@ export 'src/classes/legacy_uuid.dart';
 export 'src/types/dbpointer.dart';
 export 'src/types/base/serialization_parameters.dart';
 export 'src/types/bson_binary.dart';
+export 'src/types/bson_long.dart';
 
 export 'src/bson_codec.dart';
 export 'src/codec.dart';

--- a/lib/src/types/bson_binary.dart
+++ b/lib/src/types/bson_binary.dart
@@ -133,7 +133,7 @@ class BsonBinary extends BsonObject {
       throw ArgumentError(
           'The received Map is not a valid EJson Binary representation');
     }
-    var content = entry.value as Map<String, Object>;
+    var content = (entry.value as Map).cast<String, Object>();
     if (content.containsKey('base64') && content.containsKey('subType')) {
       String key = content['base64'] as String;
       String type = content['subType'] as String;

--- a/lib/src/types/bson_regexp.dart
+++ b/lib/src/types/bson_regexp.dart
@@ -67,7 +67,7 @@ class BsonRegexp extends BsonObject {
       throw ArgumentError(
           'The received Map is not a valid EJson Regex representation');
     }
-    var content = entry.value as Map<String, Object>;
+    var content = (entry.value as Map).cast<String, Object>();
     if (content.containsKey('pattern') && content.containsKey('options')) {
       String locPattern = content['pattern'] as String;
       String locOptions = content['options'] as String;

--- a/lib/src/types/dbpointer.dart
+++ b/lib/src/types/dbpointer.dart
@@ -44,8 +44,8 @@ class DBPointer extends BsonObject {
     var content = entry.value;
     if (content.containsKey(type$ref) && content.containsKey(type$id)) {
       String locCollection = content[type$ref] as String;
-      var locBsonObjectId =
-          BsonObjectId.fromEJson(content[type$id] as Map<String, Object>);
+      var locBsonObjectId = BsonObjectId.fromEJson(
+          (content[type$id] as Map).cast<String, Object>());
 
       return DBPointerData(
           locCollection, locBsonObjectId, BsonString(locCollection));

--- a/test/ejson_test.dart
+++ b/test/ejson_test.dart
@@ -10,7 +10,6 @@ import 'package:bson/src/types/bson_decimal_128.dart';
 import 'package:bson/src/types/bson_double.dart';
 import 'package:bson/src/types/bson_int.dart';
 import 'package:bson/src/types/bson_legacy_uuid.dart';
-import 'package:bson/src/types/bson_long.dart';
 import 'package:bson/src/types/bson_map.dart';
 import 'package:bson/src/types/bson_null.dart';
 import 'package:bson/src/types/bson_object_id.dart';

--- a/test/test_objects/binary.dart
+++ b/test/test_objects/binary.dart
@@ -75,6 +75,11 @@ groupBinary() {
         relaxed: true);
     expect(value, eJsonSource);
   });
+  test('Ejson Deserializes from json', () {
+    final ejsonString = EJsonCodec.stringify(EJsonCodec.doc2eJson(sourceMap));
+    final value = EJsonCodec.eJson2Doc(EJsonCodec.parse(ejsonString));
+    expect(value, sourceMap);
+  });
   test('Any - Deserialize from array', () {
     var value = Codec.deserialize(BsonBinary.fromHexString(arrayBuffer),
         typeByte: bsonDataArray);

--- a/test/test_objects/db_pointer.dart
+++ b/test/test_objects/db_pointer.dart
@@ -87,6 +87,11 @@ groupDbPointer() {
     var value = EJsonCodec.deserialize(BsonBinary.fromHexString(hexBuffer));
     expect(value, eJsonSource);
   });
+  test('Ejson Deserializes from json', () {
+    final ejsonString = EJsonCodec.stringify(EJsonCodec.doc2eJson(sourceMap));
+    final value = EJsonCodec.eJson2Doc(EJsonCodec.parse(ejsonString));
+    expect(value, sourceMap);
+  });
   test('Ejson Deserialize Rx', () {
     var value = EJsonCodec.deserialize(BsonBinary.fromHexString(hexBuffer),
         relaxed: true);

--- a/test/test_objects/db_ref.dart
+++ b/test/test_objects/db_ref.dart
@@ -1,6 +1,5 @@
 import 'package:bson/bson.dart';
 import 'package:bson/src/types/base/bson_object.dart';
-import 'package:bson/src/types/bson_long.dart';
 import 'package:bson/src/types/bson_object_id.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';

--- a/test/test_objects/regexp.dart
+++ b/test/test_objects/regexp.dart
@@ -84,6 +84,11 @@ groupRegexp() {
     var value = EJsonCodec.deserialize(BsonBinary.fromHexString(hexBuffer));
     expect(value, eJsonSource);
   });
+  test('Ejson Deserializes from json', () {
+    final ejsonString = EJsonCodec.stringify(EJsonCodec.doc2eJson(sourceMap));
+    final value = EJsonCodec.eJson2Doc(EJsonCodec.parse(ejsonString));
+    expect(value, sourceMap2);
+  });
   test('Ejson Deserialize Rx', () {
     var value = EJsonCodec.deserialize(BsonBinary.fromHexString(hexBuffer),
         relaxed: true);


### PR DESCRIPTION
Extends [ https://github.com/mongo-dart/bson/pull/44](https://github.com/mongo-dart/bson/pull/44) to BsonBinary, BsonRegex and DBPointer.

Also exports BsonLong